### PR TITLE
feat: Add lifecycle ignore for custom_parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -32,3 +32,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.claude/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (4.62.0)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,14 @@ resource "azurerm_databricks_workspace" "this" {
   }
 
   tags = coalesce(var.workspace.tags, var.tags)
+
+  lifecycle {
+    ignore_changes = [
+      custom_parameters[0].nat_gateway_name,
+      custom_parameters[0].public_ip_name,
+      custom_parameters[0].vnet_address_prefix,
+    ]
+  }
 }
 
 resource "azurerm_databricks_access_connector" "this" {


### PR DESCRIPTION
## Description

Add lifecycle ignore for the following custom parameters:
   * nat_gateway_name
   * public_ip_name
   * vnet_address_prefix

Currently needed as per the following bug:

https://github.com/hashicorp/terraform-provider-azurerm/issues/30209

Which recreates the workspace every time terraform runs.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Add lifecycle ignore for the following custom parameters:
* nat_gateway_name
* public_ip_name
* vnet_address_prefix


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)